### PR TITLE
feat: status

### DIFF
--- a/src/app/api/reading/[id]/latest/route.ts
+++ b/src/app/api/reading/[id]/latest/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../../../prisma/client';
+
+export async function GET(
+  request: NextRequest,
+  context: {
+    params: Promise<{ id: string }>;
+  }
+) {
+  void request;
+  try {
+    const { id } = await context.params;
+    const latestReading = await prisma.readings.findFirst({
+      where: { reference: id },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(latestReading, { status: 200 });
+  } catch (err) {
+    const error =
+      err instanceof Error ? err : new Error('An unexpected error occurred');
+    return NextResponse.json(
+      { message: `Failed to fetch latest reading: ${error.message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/application-ui/plant-component/ReadingsComponent.tsx
+++ b/src/components/application-ui/plant-component/ReadingsComponent.tsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
+import Slider from '@mui/material/Slider';
 
 interface Props {
   reference: string;
@@ -21,7 +22,8 @@ const Container: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       boxShadow: 'none',
       border: '1px solid',
       borderColor: 'divider',
-      minWidth: 300,
+      minWidth: { xs: 250, sm: 300, md: 300 },
+      overflowY: 'auto',
     }}
   >
     <CardContent>{children}</CardContent>
@@ -29,8 +31,7 @@ const Container: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 );
 
 const ReadingsComponent = ({ reference }: Props) => {
-  console.log(`ReadingsComponent: ${reference}`);
-  const { error, isLoading, readings } = useReadings(reference);
+  const { error, isLoading, reading } = useReadings(reference);
 
   if (isLoading) {
     return (
@@ -56,7 +57,7 @@ const ReadingsComponent = ({ reference }: Props) => {
     );
   }
 
-  if (!readings || readings.length == 0) {
+  if (!reading) {
     return (
       <Container>
         <Typography variant="body1" sx={{ textAlign: 'center', my: 4 }}>
@@ -66,21 +67,55 @@ const ReadingsComponent = ({ reference }: Props) => {
     );
   }
 
-  const reading = readings[readings.length - 1];
+  const raining = reading.rain ? 1 : 0;
+  const sliderSx = {
+    '& .MuiSlider-thumb': {
+      '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+        boxShadow: 'inherit',
+      },
+    },
+  };
 
   return (
     <Container>
-      <Stack sx={{ textAlign: 'center' }} divider={<Divider />} spacing={2}>
-        <Typography variant="body1">Last Reading</Typography>
-
-        <Typography variant="body2">
-          temperature: {reading.temperature}
-        </Typography>
-        <Typography variant="body2">humidity: {reading.humidity}</Typography>
-        <Typography variant="body2">light: {reading.light}</Typography>
-        <Typography variant="body2">
-          rain: {reading.rain ? 'True' : 'False'}
-        </Typography>
+      <Stack divider={<Divider />} spacing={2} sx={{ pr: 1 }}>
+        <Box>
+          <Typography>temperature</Typography>
+          <Slider
+            value={reading.temperature}
+            size="small"
+            min={0}
+            max={40}
+            valueLabelDisplay="auto"
+            sx={sliderSx}
+          />
+        </Box>
+        <Box>
+          <Typography>humidity</Typography>
+          <Slider
+            size="small"
+            value={reading.humidity}
+            min={0}
+            max={1000}
+            valueLabelDisplay="auto"
+            sx={sliderSx}
+          />
+        </Box>
+        <Box>
+          <Typography>light</Typography>
+          <Slider
+            size="small"
+            value={reading.light}
+            min={0}
+            max={1000}
+            valueLabelDisplay="auto"
+            sx={sliderSx}
+          />
+        </Box>
+        <Box>
+          <Typography>rain:</Typography>
+          <Slider size="small" value={raining} min={0} max={1} sx={sliderSx} />
+        </Box>
       </Stack>
     </Container>
   );

--- a/src/components/application-ui/plant-component/SmartgrowComponent.tsx
+++ b/src/components/application-ui/plant-component/SmartgrowComponent.tsx
@@ -9,7 +9,10 @@ import Button from '@mui/material/Button';
 import InfoIcon from '@mui/icons-material/Info';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
-import Popover from '@mui/material/Popover';
+import Dialog from '@mui/material/Dialog';
+import CloseIcon from '@mui/icons-material/Close';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
 
 import SettingsButton from './SettingsButton';
 import ReadingsComponent from './ReadingsComponent';
@@ -21,7 +24,6 @@ interface Props {
 }
 
 const SmartgrowComponent = ({ name, reference, onDeviceDelete }: Props) => {
-  console.log(`SmartgrowComponent: ${reference}`);
   const [deviceName, setDeviceName] = useState(name);
   const [notification, setNotification] = useState<{
     open: boolean;
@@ -58,10 +60,8 @@ const SmartgrowComponent = ({ name, reference, onDeviceDelete }: Props) => {
     setNotification({ ...notification, open: false });
   };
 
-  //Popover
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const open = Boolean(anchorEl);
-  const id = open ? 'simple-popover' : undefined;
+  //Dialog
+  const [open, setOpen] = useState(false);
 
   return (
     <Box
@@ -88,25 +88,26 @@ const SmartgrowComponent = ({ name, reference, onDeviceDelete }: Props) => {
           variant="contained"
           size="small"
           startIcon={<InfoIcon />}
-          onClick={(e) => setAnchorEl(e.currentTarget)}
+          onClick={() => setOpen(true)}
         >
           Status
         </Button>
       </Box>
       {open && (
-        <Popover
-          id={id}
-          open={open}
-          anchorEl={anchorEl}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'left',
-          }}
-          onClick={() => setAnchorEl(null)}
-          key={reference}
-        >
+        <Dialog open={open} onClose={() => setOpen(false)} key={reference}>
+          <IconButton
+            onClick={() => setOpen(false)}
+            sx={{
+              position: 'absolute',
+              right: 8,
+              top: 8,
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+          <DialogTitle sx={{ p: 2 }}>{reference}</DialogTitle>
           <ReadingsComponent key={reference} reference={reference} />
-        </Popover>
+        </Dialog>
       )}
 
       <SettingsButton

--- a/src/hooks/useReadings.ts
+++ b/src/hooks/useReadings.ts
@@ -6,21 +6,20 @@ import Reading from '@/lib/types/reading';
 const useReadings = (reference: string) => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
-  const [readings, setReadings] = useState<Reading[] | null>(null);
+  const [reading, setReading] = useState<Reading | null>(null);
 
   useEffect(() => {
     const fetchReading = async () => {
       try {
-        const res = await fetch(`/api/reading/${reference}`, {
+        const res = await fetch(`/api/reading/${reference}/latest`, {
           cache: 'no-store',
         });
         if (!res.ok) {
           throw new Error(`unexpected error fetching readings: ${res.status}`);
         }
 
-        const data: Reading[] = await res.json();
-        console.log(data);
-        setReadings(data);
+        const data: Reading = await res.json();
+        setReading(data);
       } catch (err) {
         setError(
           err instanceof Error ? err : new Error('An unexpected error occured')
@@ -33,7 +32,7 @@ const useReadings = (reference: string) => {
     fetchReading();
   }, [reference]);
 
-  return { isLoading, error, readings };
+  return { isLoading, error, reading };
 };
 
 export default useReadings;


### PR DESCRIPTION
-Now the readings are centered on the screen
-The readings get represented by a slider instead of the raw numbers of data -new endpoint 'latest' that returns the latest reading of the user instead of all of them